### PR TITLE
feat: remove convert page remembering you've been to it

### DIFF
--- a/src/lib/store/index.svelte.ts
+++ b/src/lib/store/index.svelte.ts
@@ -12,10 +12,6 @@ class Files {
 			result?: (IFile & { blobUrl: string; animating: boolean }) | null;
 		}[]
 	>([]);
-	public beenToConverterPage = $state(false);
-	public shouldShowAlert = $derived(
-		!this.beenToConverterPage && this.files.length > 0,
-	);
 }
 
 class Theme {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -82,8 +82,7 @@
 		log(["uploader"], `handled ${newLen - oldLen} files`);
 		ourFiles = [];
 
-		if (files.files.length > 0 && !files.beenToConverterPage)
-			goto("/convert");
+		if (files.files.length > 0) goto("/convert");
 	};
 </script>
 

--- a/src/routes/convert/+page.svelte
+++ b/src/routes/convert/+page.svelte
@@ -47,8 +47,6 @@
 		convertersRequired.every((c) => c.ready),
 	);
 
-	files.beenToConverterPage = true;
-
 	onMount(() => {
 		isSm = window.innerWidth < 640;
 		window.addEventListener("resize", () => {


### PR DESCRIPTION
this PR removes the feature where, if you upload  files then navigate away from the conversion page, it would not navigate back automatically for the duration of your session. i thought this would be helpful but it feels like a bug even though it was a feature.